### PR TITLE
chore(cmake): add script to execute cmake like clion

### DIFF
--- a/clion-cmake-test.sh
+++ b/clion-cmake-test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+mkdir -p cmake-build-debug && cd cmake-build-debug
+cmake ..
+cmake --build . --target tests
+./tests

--- a/clion-cmake-test.sh
+++ b/clion-cmake-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-mkdir -p cmake-build-debug && cd cmake-build-debug
-cmake ..
-cmake --build . --target tests
+mkdir -p cmake-build-debug
+cmake . --build cmake-build-debug
+cmake --build cmake-build-debug --target tests
 ./tests

--- a/cmake-test.sh
+++ b/cmake-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 mkdir -p cmake-build-debug
-cmake . --build cmake-build-debug
+cmake -B cmake-build-debug
 cmake --build cmake-build-debug --target tests
 ./tests


### PR DESCRIPTION
When I get back to cmake after a break, I always forget how to use it (without cluttering the root directory), so I have to boot up CLion is often overkill for a quick test. The added script executes the tests as CLion does it - and can be inspected to refresh memory ;)